### PR TITLE
Allow `$` in parameter placeholder expansion

### DIFF
--- a/src/examples/specnaz-junit-platform-examples/src/test/kotlin/ParametrizedKotlinSpec.kt
+++ b/src/examples/specnaz-junit-platform-examples/src/test/kotlin/ParametrizedKotlinSpec.kt
@@ -13,7 +13,7 @@ class ParametrizedKotlinSpec : SpecnazKotlinParams { init {
     describes("A parametrized Kotlin spec") {
         it.shouldThrow<NumberFormatException, String>("when parsing '%1' as an Int") { str ->
             Integer.parseInt(str)
-        }.provided("cafe", "BABE").withoutCause()
+        }.provided("cafe", "BABE", "$").withoutCause()
 
         it.should("respect failed assumptions by aborting the test execution") {
             assumeTrue(false)

--- a/src/main/specnaz/src/main/java/org/specnaz/params/impl/Conversions.java
+++ b/src/main/specnaz/src/main/java/org/specnaz/params/impl/Conversions.java
@@ -24,6 +24,7 @@ import org.specnaz.utils.ThrowableExpectations;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.regex.Matcher;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
@@ -341,7 +342,8 @@ public final class Conversions {
         // but it's probably better to be aware of this issue
         // sooner rather than later :)
         for (int i = size; i > 0; i--) {
-            ret = ret.replaceAll("%" + i, String.valueOf(params.get(i - 1)));
+            ret = ret.replaceAll("%" + i,
+                    Matcher.quoteReplacement(String.valueOf(params.get(i - 1))));
         }
 
         return ret;

--- a/src/main/specnaz/src/main/java/org/specnaz/utils/ThrowableExpectations.java
+++ b/src/main/specnaz/src/main/java/org/specnaz/utils/ThrowableExpectations.java
@@ -11,7 +11,7 @@ import static java.lang.String.format;
 
 /**
  * The class returned from {@link SpecBuilder#shouldThrow}
- * that allows you specify assertions on the Exception thrown in the test.
+ * that allows you to specify assertions on the Exception thrown in the test.
  * <p>
  * By default, the only thing checked is that the class of the thrown Exception matches the class passed to
  * {@link SpecBuilder#shouldThrow}.


### PR DESCRIPTION
There was a bug in the way parameter placeholder expansion was done in parametrized tests.
If the value of a parameter was a string containing the `$` character,
an attempt of substituting the placeholder with that value would result in an exception being thrown.

The reason for the bug was incorrectly using the `String.replaceAll()` method,
which actually treats the `$` and `\` characters specially in the replacement string.
The solution is to escape that string using the `Matcher.quoteReplacement()` method.

Fixes #16
